### PR TITLE
CRATE is a signed 16bit int register (charge + discharge rates)

### DIFF
--- a/MAX17048.h
+++ b/MAX17048.h
@@ -202,7 +202,7 @@ namespace EmbeddedDevices
             write(REG::STATUS, v);
         }
 
-        float crate() { return (float)read(REG::CRATE) * 0.208f; } // % per hour
+        float crate() { return (int16_t)read(REG::CRATE) * 0.208f; } // % per hour
 
         uint8_t status() { return read(REG::STATUS); }
         bool highVoltage() { return bitRead(alertFlags(), 1); }


### PR DESCRIPTION
Hi there.  Worlds smallest change but just for visibility for anyone using this library.  Change rate (CRATE) needs to be read as a int16_t instead of being cast straight to a float. 

You can actually see this same functionality in the larger sparkfun repo too: https://github.com/sparkfun/SparkFun_MAX1704x_Fuel_Gauge_Arduino_Library/blob/main/src/SparkFun_MAX1704x_Fuel_Gauge_Arduino_Library.cpp#L323